### PR TITLE
Add basic ETL script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@
 
 These instructions assume you are working on Linux.
 
+### Initialize the DB
+
+1. Create the `csi4142` user:
+
+    ```sh
+    createuser --interactive
+    ```
+
+2. Create the `csi4142` database:
+
+    ```sh
+    createdb -U csi4142 csi4142
+    ```
+
+3. Initialize the SQL schema:
+
+    ```sh
+    psql -U csi4142 -d csi4142 -a -f sql_schema.sql
+    ```
+
+### Load the `Date` Values
+
 Loading the dates from the data set into the database:
 
 1. Obtain [the dataset][dataset]
@@ -32,6 +54,20 @@ Loading the dates from the data set into the database:
 
     ```sh
     ./load_date.py
+    ```
+
+### Data Staging via ETL
+
+This uses the ETL script provided to load the remainder of the data into the
+database.
+
+1. Perform steps 1-5 from the section above, to setup Python.
+2. Modify the SQL connection parameters and other settings as necessary in the
+   `etl.py` script.
+3. Run the script:
+
+    ```sh
+    ./etl.py
     ```
 
 [dataset]: http://data.worldbank.org/data-catalog/crowd-sourced-price-collection

--- a/etl.py
+++ b/etl.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import datetime
+import sys
+import time
+
+# In this example, we use psycopg2. You can change it to another driver,
+# but then the method pgcopybulkloader won't work as we use driver-specific
+# code there.
+# You can make another function or declare facttbl (see further below) to
+# be a BatchFactTable such that you don't need special
+# bulk loading methods.
+
+import psycopg2
+
+# Depending on your system, you might have to do something like this
+# where you append the path where pygrametl is installed
+# NOTE: uncomment this if necessary
+#sys.path.append('/home/me/code')
+
+import pygrametl
+from pygrametl.datasources import CSVSource, MergeJoiningSource, SQLSource
+from pygrametl.tables import CachedDimension, SnowflakedDimension,\
+    SlowlyChangingDimension, BulkFactTable
+
+
+# This controls the behaviour of the script.
+# If the script is in debug mode, it will only insert the specified number of
+# rows into the database from the original data set (to speed up the development
+# process).
+DEBUG=True
+ROWS_TO_IMPORT=10
+
+DATA_FILE='Crowd-Sourced_Price_Collection_CSV.csv'
+DB_NAME='csi4142'
+DB_USER='csi4142'
+DB_HOST='localhost'
+DB_PASS=''
+
+
+# Connection to the target data warehouse:
+pgconn = psycopg2.connect(dbname=DB_NAME, user=DB_USER, host=DB_HOST,
+        password=DB_PASS)
+connection = pygrametl.ConnectionWrapper(pgconn)
+connection.setasdefault()
+connection.execute('set search_path to csi4142project')
+
+
+# Methods
+def pgcopybulkloader(name, atts, fieldsep, rowsep, nullval, filehandle):
+    # Here we use driver-specific code to get fast bulk loading.
+    # You can change this method if you use another driver or you can
+    # use the FactTable or BatchFactTable classes (which don't require
+    # use of driver-specifc code) instead of the BulkFactTable class.
+    global connection
+    curs = connection.cursor()
+    curs.copy_from(file=filehandle, table=name, sep=fieldsep,
+                   null=str(nullval), columns=atts)
+
+# Data dimensions
+
+locationdim = CachedDimension(
+    name='Location',
+    key='location_key',
+    attributes=['city', 'country'],
+    lookupatts=['location_key'])
+
+productdim = CachedDimension(
+    name='Product',
+    key='product_key',
+    attributes=['product_name'],
+    lookupatts=['product_key'])
+
+datedim = CachedDimension(
+    name='Date',
+    key='date_key',
+    attributes=['date', 'day_of_week', 'week_in_year', 'month', 'year', 'weekend'],
+    lookupatts=['date'])
+
+facttbl = BulkFactTable(
+    name='ProductPrice',
+    keyrefs=['date_key', 'pp_key', 'product_key', 'location_key'],
+    measures=['price'], # TODO: determine if any other measures should be listed
+    bulkloader=pgcopybulkloader,
+    bulksize=5000000,
+    nullsubst='N/A') # TODO: replace this with a better NULL substitution value
+
+# Data sources
+
+# The buffer size is set to 16384 B, because this performs best, according to
+# the pygrametl developers.
+data_set = CSVSource(open(DATA_FILE, 'r', 16384),
+                        delimiter=',')
+
+def main():
+    #[datedim.insert(row) for row in date_source]
+    count = 1
+    for row in data_set:
+        # Add the missing data to the dimension tables.
+        row['date_key'] = datedim.lookup(row, { 'date': 'Obs Date (yyyy-MM-dd)' })
+        row['price'] = row['Obs Price']
+        row['pp_key'] = count # FIXME
+        row['product_key'] = productdim.ensure(row, {
+            'product_key': 'Product Code',
+            'product_name': 'Product Name' })
+        row['location_key'] = locationdim.ensure(row, {
+            'location_key': 'Location Code',
+            'city': 'Location Name',
+            'country': 'Country' })
+
+        # Insert the data into the fact table.
+        facttbl.insert(row)
+
+        count += 1
+
+        # If in debug mode, only insert the specified number of rows into the
+        # database.
+        if DEBUG and count > ROWS_TO_IMPORT:
+            break
+    connection.commit()
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 psycopg2==2.7.1
+pygrametl==2.5


### PR DESCRIPTION
Add basic ETL script for staging the data into the database.
Add instructions on DB schema setup and ETL script usage to the `README.md`.
Add `pygrametl` to the requirements file.